### PR TITLE
feat: add extraction of enums from markers

### DIFF
--- a/src/parsers/marker.parser.ts
+++ b/src/parsers/marker.parser.ts
@@ -24,7 +24,7 @@ export class MarkerParser implements ParserInterface {
 			if (!firstArg) {
 				return;
 			}
-			const strings = getStringsFromExpression(firstArg);
+			const strings = getStringsFromExpression(firstArg, sourceFile);
 			collection = collection.addKeys(strings);
 		});
 		return collection;

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -38,7 +38,7 @@ export class ServiceParser implements ParserInterface {
 				if (!firstArg) {
 					return;
 				}
-				const strings = getStringsFromExpression(firstArg);
+				const strings = getStringsFromExpression(firstArg, sourceFile);
 				collection = collection.addKeys(strings);
 			});
 		});

--- a/tests/parsers/marker.parser.spec.ts
+++ b/tests/parsers/marker.parser.spec.ts
@@ -61,4 +61,28 @@ describe('MarkerParser', () => {
 		const keys = parser.extract(contents, componentFilename).keys();
 		expect(keys).to.deep.equal(['DYNAMIC_TRAD.val1', 'DYNAMIC_TRAD.val2']);
 	});
+
+	it('should extract the value of string enums', () => {
+		const contents = `
+		import { marker } from '@biesbjerg/ngx-translate-extract-marker';
+		import { TEST_ENUM } from './tests/utils/enum';
+
+		export enum DYNAMIC_TRAD {
+			string = 'string',
+			number = 5
+		}
+
+		export class AppModule {
+			constructor() {
+				marker(DYNAMIC_TRAD.string);
+				marker(DYNAMIC_TRAD.number.toString());
+				marker("Extract a " + DYNAMIC_TRAD.string + " value");
+				marker(TEST_ENUM.test);
+				marker(TEST_ENUM.wrong);
+			}
+		}
+		`;
+		const keys = parser.extract(contents, componentFilename).keys();
+		expect(keys).to.deep.equal(['string', 'Extract a string value', 'test']);
+	});
 });

--- a/tests/utils/enum.ts
+++ b/tests/utils/enum.ts
@@ -1,0 +1,4 @@
+export enum TEST_ENUM {
+	test = 'test',
+	wrong = 5
+}


### PR DESCRIPTION
Allows for the marker extraction to also extract enum members to improve i18n files generation.

Removes the limitation that was in place on the query of `CallExpression` to allow `PropertyAccessExpression`. This allows to get markers with Enum. By testing the structure of the `Expression`, we gather the information relative to the enum member that we are looking for. By browsing the files that contain the enumeration (whether locally or in the imports of the file), we can find the value that the enum member was initialized to. If the value is of type `string` we keep it in the extracted list.